### PR TITLE
Fix: Enforce capacity limits in signup endpoint

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Check if activity is at capacity
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Activity is at full capacity ({activity['max_participants']} participants)"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
## Description
This PR fixes the critical issue where students could sign up for activities even when they were at full capacity.

## Changes Made
- ✅ Added capacity validation in the `signup_for_activity()` function
- ✅ Check if `len(activity["participants"]) >= activity["max_participants"]` before allowing signup
- ✅ Return HTTP 400 with a clear error message when activity is full
- ✅ Error message includes the actual capacity limit for better user experience

## Testing
The fix ensures that:
- Students cannot sign up when an activity is at maximum capacity
- A meaningful error message is returned: `"Activity is at full capacity (X participants)"`
- Existing functionality for valid signups remains unchanged

## Fixes
Closes #8

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is a high-priority fix that addresses a fundamental functionality issue in the school activities signup system.